### PR TITLE
Solution and tests for task 12 - GET /api/articles/:article_id (comment_count)

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -72,6 +72,15 @@ describe("/api/articles/:article_id", () => {
           );
         });
     });
+    test("GET 200: Should also return a comment count for the specified article_id", () => {
+      return request(app)
+      .get("/api/articles/1")
+      .expect(200)
+      .then(({ body }) => {
+        const { article } = body;
+        expect(article.comment_count).toBe(11)
+      })
+    })
     test("GET 404: Should return a 404 'Not found' error if the article ID is not in the database", () => {
       return request(app)
         .get("/api/articles/9999")

--- a/endpoints.json
+++ b/endpoints.json
@@ -114,6 +114,7 @@
           "author": "icellusedkars",
           "body": "some gifs",
           "created_at": "2020-11-03T09:12:00.000Z",
+          "comment count": 2,
           "votes": 10,
           "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
         }

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -2,7 +2,13 @@ const db = require("../db/connection");
 
 exports.selectArticleById = (article_id) => {
   return db
-    .query(`SELECT * FROM articles WHERE article_id=$1`, [article_id])
+    .query(`SELECT articles.article_id, title, topic, articles.body, articles.author, articles.created_at::timestamp, articles.votes, article_img_url,
+    CAST(COUNT(comment_id) AS INT) AS comment_count
+    FROM articles 
+    LEFT OUTER JOIN comments ON articles.article_id=comments.article_id
+    WHERE articles.article_id=$1
+    GROUP BY articles.article_id ORDER BY articles.created_at DESC
+    ;`, [article_id])
     .then(({ rows }) => {
       if (rows.length === 0) {
         return Promise.reject({ status: 404, message: "Not found" });


### PR DESCRIPTION
The article response now also includes a comment count.

No changes to error handling as this is already covered by previous tests under "GET /api/articles/:article_id".